### PR TITLE
Fix scaling of stroke-width

### DIFF
--- a/applytransform.py
+++ b/applytransform.py
@@ -56,7 +56,8 @@ class ApplyTransform(inkex.Effect):
                     # pixelsnap ext assumes scaling is similar in x and y
                     # and uses the x scale...
                     # let's try to be a bit smarter
-                    stroke_width *= math.sqrt(transf[0][0]**2 + transf[1][1]**2)
+                    # the least terrible option is using the geometric mean
+                    stroke_width *= math.sqrt(transf[0][0] * transf[1][1])
                     style['stroke-width'] = str(stroke_width)
                     update = True
                 except AttributeError:

--- a/applytransform.py
+++ b/applytransform.py
@@ -68,8 +68,6 @@ class ApplyTransform(inkex.Effect):
         if 'transform' in node.attrib:
             del node.attrib['transform']
 
-        self.scaleStrokeWidth(node, transf)
-
         node = ApplyTransform.objectToPath(node)
 
         if 'd' in node.attrib:
@@ -77,6 +75,8 @@ class ApplyTransform(inkex.Effect):
             p = cubicsuperpath.parsePath(d)
             applyTransformToPath(transf, p)
             node.set('d', cubicsuperpath.formatPath(p))
+
+            self.scaleStrokeWidth(node, transf)
 
         elif node.tag in [inkex.addNS('polygon', 'svg'),
                           inkex.addNS('polyline', 'svg')]:
@@ -93,12 +93,18 @@ class ApplyTransform(inkex.Effect):
             points = ' '.join(points)
             node.set('points', points)
 
+            self.scaleStrokeWidth(node, transf)
+
         elif node.tag in [inkex.addNS('rect', 'svg'),
                           inkex.addNS('text', 'svg'),
                           inkex.addNS('image', 'svg'),
                           inkex.addNS('use', 'svg'),
                           inkex.addNS('circle', 'svg')]:
             node.set('transform', formatTransform(transf))
+
+        else:
+            # e.g. <g style="...">
+            self.scaleStrokeWidth(node, transf)
 
         for child in node.getchildren():
             self.recursiveFuseTransform(child, transf)

--- a/applytransform.py
+++ b/applytransform.py
@@ -39,12 +39,7 @@ class ApplyTransform(inkex.Effect):
 
         return node
 
-    def recursiveFuseTransform(self, node, transf=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]):
-        transf = composeTransform(transf, parseTransform(node.get("transform", None)))
-
-        if 'transform' in node.attrib:
-            del node.attrib['transform']
-
+    def scaleStrokeWidth(self, node, transf):
         if 'style' in node.attrib:
             style = node.attrib.get('style')
             style = simplestyle.parseStyle(style)
@@ -66,6 +61,14 @@ class ApplyTransform(inkex.Effect):
             if update:
                 style = simplestyle.formatStyle(style)
                 node.attrib['style'] = style
+
+    def recursiveFuseTransform(self, node, transf=[[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]):
+        transf = composeTransform(transf, parseTransform(node.get("transform", None)))
+
+        if 'transform' in node.attrib:
+            del node.attrib['transform']
+
+        self.scaleStrokeWidth(node, transf)
 
         node = ApplyTransform.objectToPath(node)
 


### PR DESCRIPTION
1. Use geometric mean of x and y scalings for stroke-width scaling

    No solution can be perfect when the x and y multipliers are not equal, but using the geometric mean seems the least bad.

    At least when the multipliers are equal, it will give the correct scaling factor. (The previous solution would exaggerate by a factor of sqrt(2).)

    Issue #12 is partially linked to this. (I think there are two parts to it, though.)

2. Re-factor (to make 3. neater)

3. Don't apply scaling of stroke-width if the transform attribute will still be applied to the given node. (This helps avoid applying the same transformation twice to the same stroke.)