### PR TITLE
Revised to work with Inkscape 1.0+

### DIFF
--- a/applytransform.inx
+++ b/applytransform.inx
@@ -4,9 +4,6 @@
 	<id>com.klowner.filter.applytransform</id>
 	<dependency type="executable" location="extensions">applytransform.py</dependency>
 	<dependency type="executable" location="extensions">inkex.py</dependency>
-	<dependency type="executable" location="extensions">simplestyle.py</dependency>
-	<dependency type="executable" location="extensions">simpletransform.py</dependency>
-	<dependency type="executable" location="extensions">cubicsuperpath.py</dependency>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>


### PR DESCRIPTION
Updated the extension so that it works in Inkscape 1.0+. Not certain about backwards compatibility with earlier versions, though. Replaced no-op transform on primitive shapes with a user-friendly error message alerting the user that the operation is not supported.