### PR TITLE
Further update extension for 1.0

### DIFF
--- a/applytransform.inx
+++ b/applytransform.inx
@@ -11,6 +11,6 @@
 		</effects-menu>
 	</effect>
 	<script>
-		<command reldir="extensions" interpreter="python">applytransform.py</command>
+		<command location="inx" interpreter="python">applytransform.py</command>
 	</script>
 </inkscape-extension>

--- a/applytransform.inx
+++ b/applytransform.inx
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
-	<_name>Apply Transform</_name>
+	<name>Apply Transform</name>
 	<id>com.klowner.filter.applytransform</id>
 	<dependency type="executable" location="extensions">applytransform.py</dependency>
 	<dependency type="executable" location="extensions">inkex.py</dependency>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>
-			<submenu _name="Modify Path" />
+			<submenu name="Modify Path" />
 		</effects-menu>
 	</effect>
 	<script>

--- a/applytransform.inx
+++ b/applytransform.inx
@@ -2,8 +2,6 @@
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
 	<name>Apply Transform</name>
 	<id>com.klowner.filter.applytransform</id>
-	<dependency type="executable" location="extensions">applytransform.py</dependency>
-	<dependency type="executable" location="extensions">inkex.py</dependency>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>

--- a/applytransform.py
+++ b/applytransform.py
@@ -13,9 +13,9 @@ from inkex.styles import Style
 NULL_TRANSFORM = Transform([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]])
 
 
-class ApplyTransform(inkex.Effect):
+class ApplyTransform(inkex.EffectExtension):
     def __init__(self):
-        inkex.Effect.__init__(self)
+        super(ApplyTransform, self).__init__()
 
     def effect(self):
         if self.svg.selected:


### PR DESCRIPTION
According to [Updating your Extension for 1.0](https://wiki.inkscape.org/wiki/index.php?title=Updating_your_Extension_for_1.0) some more changes can be made to the extension:

- Underscores in inx parameter tags and attributes for translation can be dropped entirely. Use translatable="no" to make an item (e.g. a unit name) untranslatable.
- For specifying the command in the .inx file, a new parameter 'location' can be used. It's the recommended way in 1.0, and it will assume the path is relative to the .inx file location.
- Remove redundant \<dependency\>s from .inx file as the script \<command\> is automatically added as a dependency. Also inkex is an implicit dependency.
