### PR TITLE
Enhance comparison tests

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,57 @@
+# Tests
+
+This Inkscape extension is tested with comparison tests.
+
+## Running Tests
+
+You must install the program `pytest` in order to run these tests. Both Pytest and Pytest-Coverage are required to run tests.
+
+Usually the best way to install it is: 
+
+```shell
+$ pip3 install -r tests/dev_requirements.txt
+```
+
+You may run all tests by omitting any other parameters.
+
+```shell
+$ pytest
+```
+
+## Test Files
+
+The test files are in the `tests` directory. This test is a "comparison" test. It will fail whenever the output changes, so it will need to be updated to reflect changes.
+
+
+## Test Data
+
+As well as python test files, each test will normally depend on additional data. From source svg files, to output comparison tests and other such things.
+
+This data is always held in `tests/data`. Source svg files go in to `tests/data/svg`, output comparison files in to `tests/data/refs`.
+When writing tests, please make sure your data goes into the right directory. If you are updating the comparison test,
+usually you just need to rename the `export` file generated and remove the `.export` suffix to enable it.
+
+To do so run the following command:
+
+```shell
+EXPORT_COMPARE=1 $ pytest
+```
+
+This will write a new output comparison file in to `tests/data/refs`.
+
+
+## Testing Options
+
+Tests can be run with these options that are provided as environment variables:
+
+    FAIL_ON_DEPRECATION=1 - Will instantly fail any use of deprecated APIs
+    EXPORT_COMPARE=1 - Generate output files from comparisons. This is useful for manually checking the output as well as updating the comparison data.
+    NO_MOCK_COMMANDS=1 - Instead of using the mock data, actually call commands. This will also generate the msg files similar to export compare.
+    INKSCAPE_COMMAND=/other/inkscape - Use a different Inkscape (for example development version) while running commands. Works outside of tests too.
+    XML_DIFF=1 - Attempt to output an XML diff file, this can be useful for debugging to see differences in context.
+    DEBUG_KEY=1 - Export mock file keys for debugging. This is a highly specialised option for debugging key generation.
+
+
+## More Information
+
+For further details see the official Inkscape Extension repository, currently residing at: https://gitlab.com/inkscape/extensions/-/blob/master/TESTING.md

--- a/applytransform.inx
+++ b/applytransform.inx
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <inkscape-extension xmlns="http://www.inkscape.org/namespace/inkscape/extension">
 	<name>Apply Transform</name>
-	<id>com.klowner.filter.applytransform</id>
+	<id>com.klowner.filter.apply_transform</id>
 	<effect>
 		<object-type>all</object-type>
 		<effects-menu>

--- a/applytransform.py
+++ b/applytransform.py
@@ -19,7 +19,7 @@ class ApplyTransform(inkex.EffectExtension):
 
     def effect(self):
         if self.svg.selected:
-            for id, shape in self.svg.selected.items():
+            for shape in self.svg.selected.items():
                 self.recursiveFuseTransform(shape)
         else:
             self.recursiveFuseTransform(self.document.getroot())

--- a/tests/data/refs/applytransform.out
+++ b/tests/data/refs/applytransform.out
@@ -30,11 +30,11 @@
 
   <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
   <g id="issue-15">
-  <ellipse cx="240.0" cy="50.0" rx="220.0" ry="15.0" style="fill:purple;stroke-width:1.5"/>
+    <ellipse cx="240.0" cy="50.0" rx="220.0" ry="15.0" style="fill:purple;stroke-width:1.5"/>
 
-  <ellipse cx="-220.0" cy="21.0" rx="190.0" ry="6.0" style="fill:lime;stroke-width:1.5"/>
+    <ellipse cx="-220.0" cy="21.0" rx="190.0" ry="6.0" style="fill:lime;stroke-width:1.5"/>
 
-  <ellipse cx="174.0" cy="90.5" rx="170.0" ry="15.0" style="fill:yellow;stroke-width:1.5"/>
+    <ellipse cx="174.0" cy="90.5" rx="170.0" ry="15.0" style="fill:yellow;stroke-width:1.5"/>
 
   </g>
 
@@ -42,8 +42,8 @@
 
   <polyline points="0.0,20.0 40.0,20.0 40.0,40.0 80.0,40.0 80.0,60.0 120.0,60.0 120.0,80.0" style="fill:white;stroke:red;stroke-width:2.8284271247461903"/>
 
-  <!-- issue inkscape-applytransforms/issues/19 -->
-  <g id="Sketch">
+  <!-- issue inkscape-applytransforms/issues/19 - `circle` elements don't get transformed -->
+  <g id="issue-19">
 
     <path id="Sketch_w0000" d="M 55.4689 1.85809 C 56.1774 -19.2923 44.7963 -39.0049 26.1253 -48.9665 L 4.25249 -62.3521 C 1.64248 -63.9493 -1.64246 -63.9493 -4.25249 -62.3521 L -26.1253 -48.9665 C -44.7963 -39.0049 -56.1774 -19.2923 -55.4689 1.85809 L -56.1247 27.4933 C -56.203 30.5522 -54.5605 33.3971 -51.8722 34.8588 L -29.3436 47.1084 C -11.3811 58.2972 11.3811 58.2972 29.3436 47.1084 L 51.8722 34.8588 C 54.5605 33.3971 56.2029 30.5523 56.1247 27.4933 Z" stroke="#000000" stroke-width="0.35 px" style="fill:none;fill-rule:evenodd;stroke-dasharray:none;stroke-miterlimit:4;stroke-width:0.35"/>
 
@@ -58,4 +58,22 @@
     <title>Sketch</title>
     </g>
 
+
+  <!-- issue inkscape-applytransforms/issues/10 - remove all scale transformations  -->
+  <rect id="issue-10" d="M -403.715 -109.392 L -347.83 -56.8598 L -311.766 -95.2256 L -367.652 -147.757 Z" style="fill:#0000ff"/>
+<!--   <rect
+    id="issue-10"
+    y="260.50827"
+    x="-175.45432"
+    height="52.654354"
+    width="76.699425"
+    style="fill:#0000ff"
+    transform="rotate(43.228035)
+                scale(1,-1)" /> -->
+
+<!--
+  rect
+  text
+  image
+  use -->
 </svg>

--- a/tests/data/refs/applytransform.out
+++ b/tests/data/refs/applytransform.out
@@ -1,79 +1,232 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="-450 -150 1000 350">
-  
-  <g fill="grey">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" viewBox="0 0 1500 1500">
 
-    <path id="heart" d="M -19.3092 72.1117 C -22.8819 69.1139 -22.4291 65.6819 -18.1214 63.1084 C -13.8137 60.535 -6.30558 59.2111 1.57477 59.6355 C 9.45511 60.0598 16.5104 62.168 20.0831 65.1658 C 16.5104 62.168 16.9632 58.7359 21.2709 56.1625 C 25.5786 53.5891 33.0867 52.2652 40.9671 52.6895 C 48.8474 53.1139 55.9028 55.2221 59.4754 58.2199 C 69.4754 66.6109 66.3446 77.3172 50.0831 90.3388 C 13.8216 86.5784 -9.30922 80.5027 -19.3092 72.1117 Z"/>
-      
-  </g>
+  <style>
+    text.desc {
+      font-size: 24px;
+    }
+  </style>
 
-  <use xlink:href="#heart" fill="none" stroke="red" stroke-width="2"/>
+  <!-- test for path -->
+  <text class="desc" x="420" y="150">Single Path</text>
+  <path id="heart" d="M 510 30 C 510 22.8547 513.812 16.2521 520 12.6795 C 526.188 9.10684 533.812 9.10684 540 12.6795 C 546.188 16.2521 550 22.8547 550 30 C 550 22.8547 553.812 16.2521 560 12.6795 C 566.188 9.10684 573.812 9.10684 580 12.6795 C 586.188 16.2521 590 22.8547 590 30 C 590 50 576.667 70 550 90 C 523.333 70 510 50 510 30 Z" style="fill:#db0153"/>
 
-  <g id="layer1">
-
-    <g id="g29">
-
-      <g id="g18">
-
-        <path id="rect10" style="fill:#0000ff;fill-rule:evenodd;stroke-width:0.15314874409701196" d="M 78.2342 76.2759 L 134.836 91.2271 L 116.343 165.43 L 59.7416 150.479 Z"/>
-
-        <path id="path12" style="fill:#ff0000;fill-rule:evenodd;stroke-width:0.24080963320884827" d="M 183.374 108.749 C 180.309 121.049 173.642 131.861 164.84 138.806 C 156.039 145.75 145.823 148.26 136.44 145.781 C 127.058 143.303 119.278 136.04 114.811 125.59 C 110.344 115.141 109.557 102.36 112.622 90.0603 C 119.006 64.4472 140.019 47.8673 159.556 53.0281 C 179.094 58.1889 189.758 83.1361 183.374 108.749 Z"/>
-
-      </g>
-
-      <path id="path20" style="fill:#ffff00;fill-rule:evenodd;stroke-width:0.2751655095098435" d="M 214.244 168.038 L 190.208 148.616 L 157.047 147.757 L 172.174 130.035 L 155.882 107.909 L 189.266 116.378 L 212.359 103.561 L 217.864 126.518 L 248.428 140.723 L 218.447 146.442 Z"/>
+  <!-- test for path in group with use -->
+  <text class="desc" x="420" y="400">Path in Group with use</text>
+  <g id="test-path-group">
+    <g id="tpg_1" fill="grey">
+      <path id="heart2" d="M 480.691 322.112 C 477.118 319.114 477.571 315.682 481.879 313.108 C 486.186 310.535 493.694 309.211 501.575 309.635 C 509.455 310.06 516.51 312.168 520.083 315.166 C 516.51 312.168 516.963 308.736 521.271 306.163 C 525.579 303.589 533.087 302.265 540.967 302.69 C 548.847 303.114 555.903 305.222 559.475 308.22 C 569.475 316.611 566.345 327.317 550.083 340.339 C 513.822 336.578 490.691 330.503 480.691 322.112 Z"/>
     </g>
-
+    <!-- Shape use  not yet supported -->
+    <!-- <use id="heart2_1" xlink:href="#heart2" style="fill:none;stroke:red;stroke-width:2" /> -->
   </g>
 
+  <!-- test for mulitple sub-groups and matrices -->
+  <text class="desc" x="720" y="200">Path in mulitple sub-groups and matrices</text>
+  <g id="mulitple-sub-groups">
+    <g id="msg-1">
+      <!-- scale(0.5, 0.5) -->
+      <g id="msg-2">
+        <!-- skewX(45&#176;) -->
+        <path id="msg-rectangle" style="fill:red;stroke:#5f0ce8;stroke-width:1.0" d="M 843.57 23.2491 L 883.57 23.2491 L 923.57 63.2491 L 883.57 63.2491 Z"/>
+        <!-- skewY(45&#176;) -->
+        <path id="msg-circle" style="fill:blue;stroke:#5f0ce8;stroke-width:1.0" d="M 875 146.5 C 875 153.13 872.366 156.855 867.678 156.855 C 862.989 156.855 856.63 153.13 850 146.5 C 843.37 139.87 837.011 130.877 832.322 121.5 C 827.634 112.123 825 103.13 825 96.5 C 825 89.8696 827.634 86.1447 832.322 86.1447 C 837.011 86.1447 843.37 89.8696 850 96.5 C 856.63 103.13 862.989 112.123 867.678 121.5 C 872.366 130.877 875 139.87 875 146.5 Z"/>
+      </g>
+      <path id="msg-star" style="fill:yellow;stroke:#5f0ce8;stroke-width:2.0" d="M 940.001 129.023 L 919.059 114.358 L 895.107 123.296 L 902.582 98.8476 L 886.68 78.8291 L 912.242 78.3838 L 926.367 57.074 L 934.689 81.2473 L 959.321 88.0955 L 938.903 103.481 Z"/>
+    </g>
+  </g>
 
-  <circle cx="0.0" cy="0.0" r="120.0" style="fill:red;stroke-width:1.5"/>
+  <!-- test for cicle -->
+  <text class="desc" x="720" y="400">Circle</text>
+  <circle id="circle" cx="900.0" cy="300.0" r="60.0" style="fill:red;stroke-width:1.5"/>
 
-  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
+  <!-- test for polygon -->
+  <text class="desc" x="420" y="620">Polygon</text>
+  <polygon id="triangle" points="550.0,455.0 500.0,545.0 590.0,555.0" style="fill:lime;stroke:purple;stroke-width:1.0606601717798214"/>
+
+  <!-- test for polyline -->
+  <text class="desc" x="720" y="620">Polyline</text>
+  <polyline id="steps" points="800.0,520.0 840.0,520.0 840.0,540.0 880.0,540.0 880.0,560.0 920.0,560.0 920.0,580.0" style="fill:#11768c;stroke:red;stroke-width:2.8284271247461903"/>
+
+  <!-- test for text -->
+  <text class="desc" x="380" y="1160">Text</text>
+<!-- Shape rect not yet supported
+  <g
+    id="text"
+    transform="translate(380,1060)">
+    <text id="text-1" x="20" y="35" style="font-family:sans-serif;font-style:italic;font-size:13px">My</text>
+    <text id="text-2" x="40" y="35" style="font-family:sans-serif;font-style:bold;font-size:30px">cat</text>
+    <text id="text-3" x="55" y="55" style="font-family:sans-serif;font-style:italic;font-size:13px">is</text>
+    <text id="text-4" x="65" y="55" style="font-family:serif;font-style:italic;font-size:30px" fill="red">Grumpy!</text>
+  </g>
+-->
+
+  <!-- test for text with tspan -->
+  <text class="desc" x="720" y="1160">Text with tspan</text>
+<!-- Shape text not yet supported
+  <text
+    id="text-tspan"
+    style="font-style:oblique;font-size:18px;font-family:'DejaVu Sans'"
+    transform="translate(720,1060)">
+
+    <tspan id="text-tspan-1" x="40" y="20">The quick brown fox</tspan>
+    <tspan id="text-tspan-2" x="80" y="40">jumps over the lazy dog.</tspan>
+  </text>
+-->
+
+  <!-- test for image -->
+
+
+  <!-- test for symbol/use -->
+  <!-- Source: SELFHTML (https://wiki.selfhtml.org/wiki/SVG/Transformationen) -->
+  <text class="desc" x="120" y="620">Tangram</text>
+<!-- Shape use not yet supported
+  <style>
+    .one {
+      fill: #dfac20;
+    }
+    .two {
+      fill: #306f91
+    }
+    .three {
+      fill: #df6c20;
+    }
+    .four {
+      fill: #c32e04;
+    }
+    .five {
+      fill: #5c82d9;
+    }
+    .six {
+      fill: #bfbfbf;
+    }
+    .seven {
+      fill: #8db243;
+    }
+    text.tangram {
+      font-size: 24px;
+    }
+    path.tangram {
+      stroke-width: 1;
+      stroke: white;
+    }
+  </style>
+
+  <defs>
+    <title>Templates Tangram-Figures</title>
+    <symbol id="triangle_big">
+      <desc>the big triangle</desc>
+      <path class="tangram" d="m0,0 132,132 132-132z" />
+    </symbol>
+    <symbol id="triangle_medium">
+      <desc>the medium triangle</desc>
+      <path class="tangram" d="m0,0 h132 v132 z" />
+    </symbol>
+    <symbol id="triangle_small">
+      <desc>the small triangle</desc>
+      <path class="tangram" d="m0,66 l66,66v-132z" />
+    </symbol>
+    <symbol id="square">
+      <desc>the square rectangle</desc>
+      <path class="tangram" d="m0,0 v94 h94 v-94z" />
+    </symbol>
+    <symbol id="para">
+      <desc>the paralellogram</desc>
+      <path class="tangram" d="m66,0 l-67,67 v132 l67-67 z" />
+    </symbol>
+    <symbol id="tangram-square">
+      <text class="tangram" x="10" y="290">square</text>
+      <use id="tangram-square_part1" xlink:href="#triangle_big" class="one" />
+      <use id="tangram-square_part2" xlink:href="#triangle_big" class="two" transform="scale(-1 1) rotate(90)" />
+      <use id="tangram-square_part3" xlink:href="#triangle_medium" class="three" transform="translate(264,132) rotate(90)" />
+      <use id="tangram-square_part4" xlink:href="#triangle_small" class="four" x="132" y="66" />
+      <use id="tangram-square_part5" xlink:href="#square" class="six" transform="translate(132,132) rotate(45)" />
+      <use id="tangram-square_part6" xlink:href="#para" class="seven" x="198" y="0" />
+      <use id="tangram-square_part7" xlink:href="#triangle_small" class="five" transform="translate(132,197) rotate(90)" />
+    </symbol>
+    <symbol id="tangram-ship">
+      <text class="tangram" x="40" y="250">ship</text>
+      <use id="tangram-ship_part1" xlink:href="#triangle_big" class="one" transform="translate(140,0) rotate(90)" />
+      <use id="tangram-ship_part2" xlink:href="#triangle_big" class="two" transform="translate(290,0)  rotate(90)" />
+      <use id="tangram-ship_part3" xlink:href="#triangle_medium" class="three" transform="translate(400,80) scale(-1 1) rotate(45)" />
+      <use id="tangram-ship_part4" xlink:href="#triangle_small" class="four" transform="translate(281,218) rotate(45)" />
+      <use id="tangram-ship_part5" xlink:href="#para" class="seven" transform="translate(374,218) rotate(45) " />
+      <use id="tangram-ship_part6" xlink:href="#triangle_small" class="five" transform="translate(187,311) rotate(135)" />
+      <use id="tangram-ship_part7" xlink:href="#square" class="six" transform="translate(140,264)" />
+    </symbol>
+    <symbol id="tangram-cat">
+      <text class="tangram" x="30" y="50">cat</text>
+      <use id="tangram-cat_part1" xlink:href="#triangle_big" class="one" transform="translate(300,95) rotate(110)" />
+      <use id="tangram-cat_part2" xlink:href="#triangle_big" class="two" transform="translate(300,95) scale(-1 1) rotate(115)" />
+      <use id="tangram-cat_part3" xlink:href="#triangle_medium" class="three" transform="translate(300,95) rotate(65)" />
+      <use id="tangram-cat_part4" xlink:href="#triangle_small" class="four" transform="translate(66,40) scale(-1 1)" />
+      <use id="tangram-cat_part5" xlink:href="#para" class="seven" transform="translate(540,-25) rotate(20)" />
+      <use id="tangram-cat_part6" xlink:href="#triangle_small" class="five" transform="translate(66,40) " />
+      <use id="tangram-cat_part7" xlink:href="#square" class="six" transform="translate(66,107) rotate(45)" />
+    </symbol>
+    <symbol id="tangram-bird">
+      <text class="tangram" x="30" y="50">bird</text>
+      <use id="tangram-bird_part1" xlink:href="#triangle_big" class="one" transform="translate(227,162)" />
+      <use id="tangram-bird_part2" xlink:href="#triangle_big" class="two" transform="translate(162,362) scale(1 -1)" />
+      <use id="tangram-bird_part3" xlink:href="#triangle_medium" class="three" transform="translate(353,165) rotate(-90)" />
+      <use id="tangram-bird_part4" xlink:href="#triangle_small" class="four" transform="translate(487,97) rotate(90)" />
+      <use id="tangram-bird_part5" xlink:href="#para" class="seven" transform="translate(50,23) scale(-1 1) rotate(45) " />
+      <use id="tangram-bird_part6" xlink:href="#triangle_small" class="five" transform="translate(227,228) scale(1-1) rotate(90)" />
+      <use id="tangram-bird_part7" xlink:href="#square" class="six" transform="translate(227,162) rotate(45)" />
+    </symbol>
+  </defs>
+  <g id="tangram" transform="scale(0.5 0.5)">
+    <use id="t_square" xlink:href="#tangram-square" x="10" y="10" />
+    <use id="t_ship" xlink:href="#tangram-ship" x="400" y="10" />
+    <use id="t_cat" xlink:href="#tangram-cat" x="10" y="400" />
+    <use id="t_bird" xlink:href="#tangram-bird" x="10" y="730" />
+  </g>
+-->
+
+  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group -->
+  <text class="desc" x="380" y="960">Issue #15 - apply to an ellipse in a group</text>
   <g id="issue-15">
-    <ellipse cx="240.0" cy="50.0" rx="220.0" ry="15.0" style="fill:purple;stroke-width:1.5"/>
-
-    <ellipse cx="-220.0" cy="21.0" rx="190.0" ry="6.0" style="fill:lime;stroke-width:1.5"/>
-
-    <ellipse cx="174.0" cy="90.5" rx="170.0" ry="15.0" style="fill:yellow;stroke-width:1.5"/>
+    <ellipse id="issue-15_1" cx="550.0" cy="750.0" rx="50.0" ry="15.0" style="fill:#0050DB;stroke-width:1.5"/>
+    <ellipse id="issue-15_2" cx="550.0" cy="800.0" rx="30.0" ry="40.0" style="fill:#0CB5F2;stroke-width:1.5"/>
+    <ellipse id="issue-15_3" cx="550.0" cy="860.0" rx="30.0" ry="15.0" style="fill:#05E8D0;stroke-width:1.5"/>
 
   </g>
-
-  <polygon points="-200.0,3.0 -250.0,57.0 -160.0,63.0" style="fill:lime;stroke:purple;stroke-width:0.8215838362577491"/>
-
-  <polyline points="0.0,20.0 40.0,20.0 40.0,40.0 80.0,40.0 80.0,60.0 120.0,60.0 120.0,80.0" style="fill:white;stroke:red;stroke-width:2.8284271247461903"/>
 
   <!-- issue inkscape-applytransforms/issues/19 - `circle` elements don't get transformed -->
+  <text class="desc" x="720" y="900">Issue #19 - `circle` elements don't get transformed</text>
   <g id="issue-19">
+    <path id="issue-19_1" d="M 955.469 801.858 C 956.177 780.708 944.796 760.995 926.125 751.034 L 904.252 737.648 C 901.642 736.051 898.358 736.051 895.748 737.648 L 873.875 751.033 C 855.204 760.995 843.823 780.708 844.531 801.858 L 843.875 827.493 C 843.797 830.552 845.44 833.397 848.128 834.859 L 870.656 847.108 C 888.619 858.297 911.381 858.297 929.344 847.108 L 951.872 834.859 C 954.56 833.397 956.203 830.552 956.125 827.493 Z" style="fill:#29292955;fill-rule:evenodd;stroke:#000;stroke-width:0.35"/>
 
-    <path id="Sketch_w0000" d="M 55.4689 1.85809 C 56.1774 -19.2923 44.7963 -39.0049 26.1253 -48.9665 L 4.25249 -62.3521 C 1.64248 -63.9493 -1.64246 -63.9493 -4.25249 -62.3521 L -26.1253 -48.9665 C -44.7963 -39.0049 -56.1774 -19.2923 -55.4689 1.85809 L -56.1247 27.4933 C -56.203 30.5522 -54.5605 33.3971 -51.8722 34.8588 L -29.3436 47.1084 C -11.3811 58.2972 11.3811 58.2972 29.3436 47.1084 L 51.8722 34.8588 C 54.5605 33.3971 56.2029 30.5523 56.1247 27.4933 Z" stroke="#000000" stroke-width="0.35 px" style="fill:none;fill-rule:evenodd;stroke-dasharray:none;stroke-miterlimit:4;stroke-width:0.35"/>
-
-    <circle cx="0.0" cy="0.0" r="13.1445" stroke="#000000" stroke-width="0.35 px" style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
-    <circle cx="-47.9806" cy="27.7016123259" r="3.3781999999999996" stroke="#000000" stroke-width="0.35 px" style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
-    <circle cx="0.0" cy="-55.4032246518" r="3.3782" stroke="#000000" stroke-width="0.35 px" style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
-    <circle cx="47.9806" cy="27.7016123259" r="3.3781999999999996" stroke="#000000" stroke-width="0.35 px" style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
-    <title>Sketch</title>
-    </g>
+    <circle id="issue-19_2" cx="900.0" cy="800.0" r="13.144499999999994" style="stroke:#000;stroke-width:0.35;fill:#e0e0e055"/>
+    <circle id="issue-19_3" cx="852.0194" cy="827.7016123259" r="3.3781999999999925" style="stroke:#000;stroke-width:0.35;fill:#50000055"/>
+    <circle id="issue-19_4" cx="900.0" cy="744.5967753482" r="3.3781999999999925" style="stroke:#000;stroke-width:0.35;fill:#00500055"/>
+    <circle id="issue-19_5" cx="947.9806" cy="827.7016123259" r="3.3781999999999925" style="stroke:#000;stroke-width:0.35;fill:#00005055"/>
+  </g>
 
 
   <!-- issue inkscape-applytransforms/issues/10 - remove all scale transformations  -->
-  <rect id="issue-10" d="M -403.715 -109.392 L -347.83 -56.8598 L -311.766 -95.2256 L -367.652 -147.757 Z" style="fill:#0000ff"/>
-<!--   <rect
+  <text class="desc" x="680" y="1420">Issue #19 - remove all scale transformations</text>
+<!-- Shape rect not yet supported
+  <rect
     id="issue-10"
-    y="260.50827"
-    x="-175.45432"
-    height="52.654354"
-    width="76.699425"
-    style="fill:#0000ff"
-    transform="rotate(43.228035)
-                scale(1,-1)" /> -->
+    x="350" y="20" width="100" height="100" rx="15" ry="30"
+    style="fill:#00DB67"
+    transform="translate(680, 950) rotate(45) scale(1,1)" />
+-->
 
-<!--
-  rect
-  text
-  image
-  use -->
+  <!-- test for rect -->
+  <text class="desc" x="380" y="1420">Rectangle</text>
+<!-- Shape rect not yet supported
+  <g id="test-path-group" transform="translate(380, 1260)">
+    <rect
+      id="rectangle"
+      y="-20.50827"
+      x="30.45432"
+      height="52.654354"
+      width="76.699425"
+      style="fill:#fff"
+      transform="rotate(30.228035, 15, 15)
+      scale(1, -1)" />
+  </g>
+-->
+
 </svg>

--- a/tests/data/refs/applytransform.out
+++ b/tests/data/refs/applytransform.out
@@ -26,14 +26,17 @@
   </g>
 
 
-  <!-- uniform scale -->
   <circle cx="0.0" cy="0.0" r="120.0" style="fill:red;stroke-width:1.5"/>
 
+  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
+  <g id="issue-15">
   <ellipse cx="240.0" cy="50.0" rx="220.0" ry="15.0" style="fill:purple;stroke-width:1.5"/>
 
   <ellipse cx="-220.0" cy="21.0" rx="190.0" ry="6.0" style="fill:lime;stroke-width:1.5"/>
 
   <ellipse cx="174.0" cy="90.5" rx="170.0" ry="15.0" style="fill:yellow;stroke-width:1.5"/>
+
+  </g>
 
   <polygon points="-200.0,3.0 -250.0,57.0 -160.0,63.0" style="fill:lime;stroke:purple;stroke-width:0.8215838362577491"/>
 

--- a/tests/data/svg/applytransform.svg
+++ b/tests/data/svg/applytransform.svg
@@ -68,29 +68,29 @@
   <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
   <g
     id="issue-15">
-  <ellipse
-    cx="240"
-    cy="100"
-    rx="220"
-    ry="30"
-    style="fill:purple;stroke-width:1.5"
-    transform="scale(1 0.5)" />
+    <ellipse
+      cx="240"
+      cy="100"
+      rx="220"
+      ry="30"
+      style="fill:purple;stroke-width:1.5"
+      transform="scale(1 0.5)" />
 
-  <ellipse
-    cx="220"
-    cy="70"
-    rx="190"
-    ry="20"
-    style="fill:lime;stroke-width:1.5"
-    transform="scale(-1 0.3)" />
+    <ellipse
+      cx="220"
+      cy="70"
+      rx="190"
+      ry="20"
+      style="fill:lime;stroke-width:1.5"
+      transform="scale(-1 0.3)" />
 
-  <ellipse
-    cx="210"
-    cy="45"
-    rx="170"
-    ry="15"
-    style="fill:yellow;stroke-width:1.5"
-    transform="translate(-36 45.5)" />
+    <ellipse
+      cx="210"
+      cy="45"
+      rx="170"
+      ry="15"
+      style="fill:yellow;stroke-width:1.5"
+      transform="translate(-36 45.5)" />
 
   </g>
 
@@ -104,9 +104,9 @@
   style="fill:white;stroke:red;stroke-width:4"
   transform="scale(1 0.5)"  />
 
-  <!-- issue inkscape-applytransforms/issues/19 -->
+  <!-- issue inkscape-applytransforms/issues/19 - `circle` elements don't get transformed -->
   <g
-    id="Sketch"
+    id="issue-19"
     transform="scale(1,-1)">
 
     <path
@@ -151,4 +151,29 @@
     <title>Sketch</title>
     </g>
 
+
+  <!-- issue inkscape-applytransforms/issues/10 - remove all scale transformations  -->
+  <rect
+    id="issue-10"
+    d="  m -369.08313,-196.79971 h 76.69942 v 52.65435 h -76.69942 z"
+    style="fill:#0000ff"
+    transform="rotate(43.228035)
+                scale(1,-1)" />
+
+  <!-- test for rect -->              
+  <!--
+  <rect
+    id="issue-10"
+    y="260.50827"
+    x="-175.45432"
+    height="52.654354"
+    width="76.699425"
+    style="fill:#0000ff"
+    transform="rotate(43.228035)
+                scale(1,-1)" /> -->
+
+<!--
+  text
+  image
+  use -->
 </svg>

--- a/tests/data/svg/applytransform.svg
+++ b/tests/data/svg/applytransform.svg
@@ -3,177 +3,290 @@
   xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-  viewBox="-450 -150 1000 350">
-  
-  <g
-    fill="grey"
-    transform="rotate(-10 50 100)
+  viewBox="0 0 1500 1500">
+
+  <style>
+    text.desc {
+      font-size: 24px;
+    }
+  </style>
+
+  <!-- test for path -->
+  <text class="desc" x="420" y="150">Single Path</text>
+  <path id="heart" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" transform="translate(500,0)" style="fill:#db0153" />
+
+  <!-- test for path in group with use -->
+  <text class="desc" x="420" y="400">Path in Group with use</text>
+  <g id="test-path-group" transform="translate(500, 250)">
+    <g id="tpg_1" fill="grey" transform="rotate(-10 50 100)
                 translate(-36 45.5)
                 skewX(40)
                 scale(1 0.5)">
-
-    <path
-      id="heart"
-      d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
-      
+      <path id="heart2" d="M 10,30 A 20,20 0,0,1 50,30 A 20,20 0,0,1 90,30 Q 90,60 50,90 Q 10,60 10,30 z" />
+    </g>
+    <!-- Shape use  not yet supported -->
+    <!-- <use id="heart2_1" xlink:href="#heart2" style="fill:none;stroke:red;stroke-width:2" /> -->
   </g>
 
-  <use
-    xlink:href="#heart"
-    fill="none"
-    stroke="red"
-    stroke-width="2" />
-
-  <g
-    id="layer1">
-
-    <g
-      id="g29"
-      transform="matrix(1.3021641,0.3457822,-0.22056492,0.8306145,4.9095382,-20.058683)">
-
-      <g
-        id="g18"
-        transform="matrix(0.54315553,-0.00111216,0.0108631,1.1121619,19.693503,-9.6540117)">
-
+  <!-- test for mulitple sub-groups and matrices -->
+  <text class="desc" x="720" y="200">Path in mulitple sub-groups and matrices</text>
+  <g id="mulitple-sub-groups" transform="translate(750, 0)">
+    <g id="msg-1" transform="matrix(1,0,0,1,4,-20)">
+      <!-- scale(0.5, 0.5) -->
+      <g id="msg-2" transform="matrix(0.5,0,0,0.5,0,0)">
+        <!-- skewX(45°) -->
         <path
-          id="rect10"
-          style="fill:#0000ff;fill-rule:evenodd;stroke-width:0.189051"
-          d="M 92.641788,86.498198 H 172.64179 V 166.4982 H 92.641788 Z" />
-
+          id="msg-rectangle"
+          style="fill:red;stroke-width:2;stroke:#5f0ce8"
+          d="M 92.641788,86.498198 H 172.64179 V 166.4982 H 92.641788 Z"
+          transform="matrix(1,0,1,1,0,0)" />
+        <!-- skewY(45°) -->
         <path
-          id="path12"
-          style="fill:#ff0000;fill-rule:evenodd;stroke-width:0.297262"
-          d="m 242.79893,91.25326 a 50.000002,49.999998 0 0 1 -50,50.00001 50.000002,49.999998 0 0 1 -50,-50.00001 50.000002,49.999998 0 0 1 50,-49.999993 50.000002,49.999998 0 0 1 50,49.999993 z" />
-
+          id="msg-circle"
+          style="fill:blue;stroke-width:2;stroke:#5f0ce8"
+          d="m 242,91 a 50,50 0 0 1 -50,50 50,50 0 0 1 -50,-50 50,50 0 0 1 50,-50 50,50 0 0 1 50,50 z"
+          transform="matrix(1,1,0,1,0,0)" />
       </g>
-
       <path
-        id="path20"
-        style="fill:#ffff00;fill-rule:evenodd;stroke-width:0.264583"
-        inkscape:transform-center-x="-1.5054042"
-        inkscape:transform-center-y="-2.2150546"
+        id="msg-star"
+        style="fill:yellow;stroke-width:2;stroke:#5f0ce8"
         d="m 186.0012,149.02302 -20.94187,-14.66469 -23.95268,8.93778 7.47555,-24.44854 -15.90211,-20.018423 25.56201,-0.445341 14.12463,-21.309845 8.32264,24.173299 24.63162,6.84822 -20.41834,15.38526 z" />
     </g>
-
   </g>
 
-
+  <!-- test for cicle -->
+  <text class="desc" x="720" y="400">Circle</text>
   <circle
-    cx="0"
-    cy="0"
-    r="30"
+    id="circle"
+    cx="0" cy="0" r="30"
     style="fill:red;stroke-width:1.5"
-    transform="scale(4)" />
+    transform="translate(900, 300) scale(2)" />
 
-  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
-  <g
-    id="issue-15">
-    <ellipse
-      cx="240"
-      cy="100"
-      rx="220"
-      ry="30"
-      style="fill:purple;stroke-width:1.5"
-      transform="scale(1 0.5)" />
-
-    <ellipse
-      cx="220"
-      cy="70"
-      rx="190"
-      ry="20"
-      style="fill:lime;stroke-width:1.5"
-      transform="scale(-1 0.3)" />
-
-    <ellipse
-      cx="210"
-      cy="45"
-      rx="170"
-      ry="15"
-      style="fill:yellow;stroke-width:1.5"
-      transform="translate(-36 45.5)" />
-
-  </g>
-
+  <!-- test for polygon -->
+  <text class="desc" x="420" y="620">Polygon</text>
   <polygon
+    id="triangle"
     points="200,10 250,190 160,210"
     style="fill:lime;stroke:purple;stroke-width:1.5"
-    transform="scale(-1 0.3)" />
+    transform="translate(750, 450) scale(-1 0.5)" />
 
+  <!-- test for polyline -->
+  <text class="desc" x="720" y="620">Polyline</text>
   <polyline
-  points="0,40 40,40 40,80 80,80 80,120 120,120 120,160"
-  style="fill:white;stroke:red;stroke-width:4"
-  transform="scale(1 0.5)"  />
+    id="steps"
+    points="0,40 40,40 40,80 80,80 80,120 120,120 120,160"
+    style="fill:#11768c;stroke:red;stroke-width:4"
+    transform="translate(800, 500) scale(1 0.5)"  />
+
+  <!-- test for text -->
+  <text class="desc" x="380" y="1160">Text</text>
+<!-- Shape rect not yet supported
+  <g
+    id="text"
+    transform="translate(380,1060)">
+    <text id="text-1" x="20" y="35" style="font-family:sans-serif;font-style:italic;font-size:13px">My</text>
+    <text id="text-2" x="40" y="35" style="font-family:sans-serif;font-style:bold;font-size:30px">cat</text>
+    <text id="text-3" x="55" y="55" style="font-family:sans-serif;font-style:italic;font-size:13px">is</text>
+    <text id="text-4" x="65" y="55" style="font-family:serif;font-style:italic;font-size:30px" fill="red">Grumpy!</text>
+  </g>
+-->
+
+  <!-- test for text with tspan -->
+  <text class="desc" x="720" y="1160">Text with tspan</text>
+<!-- Shape text not yet supported
+  <text
+    id="text-tspan"
+    style="font-style:oblique;font-size:18px;font-family:'DejaVu Sans'"
+    transform="translate(720,1060)">
+
+    <tspan id="text-tspan-1" x="40" y="20">The quick brown fox</tspan>
+    <tspan id="text-tspan-2" x="80" y="40">jumps over the lazy dog.</tspan>
+  </text>
+-->
+
+  <!-- test for image -->
+
+
+  <!-- test for symbol/use -->
+  <!-- Source: SELFHTML (https://wiki.selfhtml.org/wiki/SVG/Transformationen) -->
+  <text class="desc" x="120" y="620">Tangram</text>
+<!-- Shape use not yet supported
+  <style>
+    .one {
+      fill: #dfac20;
+    }
+    .two {
+      fill: #306f91
+    }
+    .three {
+      fill: #df6c20;
+    }
+    .four {
+      fill: #c32e04;
+    }
+    .five {
+      fill: #5c82d9;
+    }
+    .six {
+      fill: #bfbfbf;
+    }
+    .seven {
+      fill: #8db243;
+    }
+    text.tangram {
+      font-size: 24px;
+    }
+    path.tangram {
+      stroke-width: 1;
+      stroke: white;
+    }
+  </style>
+
+  <defs>
+    <title>Templates Tangram-Figures</title>
+    <symbol id="triangle_big">
+      <desc>the big triangle</desc>
+      <path class="tangram" d="m0,0 132,132 132-132z" />
+    </symbol>
+    <symbol id="triangle_medium">
+      <desc>the medium triangle</desc>
+      <path class="tangram" d="m0,0 h132 v132 z" />
+    </symbol>
+    <symbol id="triangle_small">
+      <desc>the small triangle</desc>
+      <path class="tangram" d="m0,66 l66,66v-132z" />
+    </symbol>
+    <symbol id="square">
+      <desc>the square rectangle</desc>
+      <path class="tangram" d="m0,0 v94 h94 v-94z" />
+    </symbol>
+    <symbol id="para">
+      <desc>the paralellogram</desc>
+      <path class="tangram" d="m66,0 l-67,67 v132 l67-67 z" />
+    </symbol>
+    <symbol id="tangram-square">
+      <text class="tangram" x="10" y="290">square</text>
+      <use id="tangram-square_part1" xlink:href="#triangle_big" class="one" />
+      <use id="tangram-square_part2" xlink:href="#triangle_big" class="two" transform="scale(-1 1) rotate(90)" />
+      <use id="tangram-square_part3" xlink:href="#triangle_medium" class="three" transform="translate(264,132) rotate(90)" />
+      <use id="tangram-square_part4" xlink:href="#triangle_small" class="four" x="132" y="66" />
+      <use id="tangram-square_part5" xlink:href="#square" class="six" transform="translate(132,132) rotate(45)" />
+      <use id="tangram-square_part6" xlink:href="#para" class="seven" x="198" y="0" />
+      <use id="tangram-square_part7" xlink:href="#triangle_small" class="five" transform="translate(132,197) rotate(90)" />
+    </symbol>
+    <symbol id="tangram-ship">
+      <text class="tangram" x="40" y="250">ship</text>
+      <use id="tangram-ship_part1" xlink:href="#triangle_big" class="one" transform="translate(140,0) rotate(90)" />
+      <use id="tangram-ship_part2" xlink:href="#triangle_big" class="two" transform="translate(290,0)  rotate(90)" />
+      <use id="tangram-ship_part3" xlink:href="#triangle_medium" class="three" transform="translate(400,80) scale(-1 1) rotate(45)" />
+      <use id="tangram-ship_part4" xlink:href="#triangle_small" class="four" transform="translate(281,218) rotate(45)" />
+      <use id="tangram-ship_part5" xlink:href="#para" class="seven" transform="translate(374,218) rotate(45) " />
+      <use id="tangram-ship_part6" xlink:href="#triangle_small" class="five" transform="translate(187,311) rotate(135)" />
+      <use id="tangram-ship_part7" xlink:href="#square" class="six" transform="translate(140,264)" />
+    </symbol>
+    <symbol id="tangram-cat">
+      <text class="tangram" x="30" y="50">cat</text>
+      <use id="tangram-cat_part1" xlink:href="#triangle_big" class="one" transform="translate(300,95) rotate(110)" />
+      <use id="tangram-cat_part2" xlink:href="#triangle_big" class="two" transform="translate(300,95) scale(-1 1) rotate(115)" />
+      <use id="tangram-cat_part3" xlink:href="#triangle_medium" class="three" transform="translate(300,95) rotate(65)" />
+      <use id="tangram-cat_part4" xlink:href="#triangle_small" class="four" transform="translate(66,40) scale(-1 1)" />
+      <use id="tangram-cat_part5" xlink:href="#para" class="seven" transform="translate(540,-25) rotate(20)" />
+      <use id="tangram-cat_part6" xlink:href="#triangle_small" class="five" transform="translate(66,40) " />
+      <use id="tangram-cat_part7" xlink:href="#square" class="six" transform="translate(66,107) rotate(45)" />
+    </symbol>
+    <symbol id="tangram-bird">
+      <text class="tangram" x="30" y="50">bird</text>
+      <use id="tangram-bird_part1" xlink:href="#triangle_big" class="one" transform="translate(227,162)" />
+      <use id="tangram-bird_part2" xlink:href="#triangle_big" class="two" transform="translate(162,362) scale(1 -1)" />
+      <use id="tangram-bird_part3" xlink:href="#triangle_medium" class="three" transform="translate(353,165) rotate(-90)" />
+      <use id="tangram-bird_part4" xlink:href="#triangle_small" class="four" transform="translate(487,97) rotate(90)" />
+      <use id="tangram-bird_part5" xlink:href="#para" class="seven" transform="translate(50,23) scale(-1 1) rotate(45) " />
+      <use id="tangram-bird_part6" xlink:href="#triangle_small" class="five" transform="translate(227,228) scale(1-1) rotate(90)" />
+      <use id="tangram-bird_part7" xlink:href="#square" class="six" transform="translate(227,162) rotate(45)" />
+    </symbol>
+  </defs>
+  <g id="tangram" transform="scale(0.5 0.5)">
+    <use id="t_square" xlink:href="#tangram-square" x="10" y="10" />
+    <use id="t_ship" xlink:href="#tangram-ship" x="400" y="10" />
+    <use id="t_cat" xlink:href="#tangram-cat" x="10" y="400" />
+    <use id="t_bird" xlink:href="#tangram-bird" x="10" y="730" />
+  </g>
+-->
+
+  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group -->
+  <text class="desc" x="380" y="960">Issue #15 - apply to an ellipse in a group</text>
+  <g id="issue-15"
+    transform="translate(550, 750)">
+    <ellipse
+      id="issue-15_1"
+      cx="0" cy="0" rx="50" ry="30"
+      style="fill:#0050DB;stroke-width:1.5"
+      transform="scale(1 0.5)" />
+    <ellipse
+      id="issue-15_2"
+      cx="0" cy="50" rx="60" ry="40"
+      style="fill:#0CB5F2;stroke-width:1.5"
+      transform="scale(0.5 1)" />
+    <ellipse
+      id="issue-15_3"
+      cx="0" cy="100" rx="30" ry="15"
+      style="fill:#05E8D0;stroke-width:1.5"
+      transform="translate(0 10)" />
+
+  </g>
 
   <!-- issue inkscape-applytransforms/issues/19 - `circle` elements don't get transformed -->
-  <g
-    id="issue-19"
-    transform="scale(1,-1)">
-
+  <text class="desc" x="720" y="900">Issue #19 - `circle` elements don't get transformed</text>
+  <g id="issue-19"
+    transform="translate(900, 800) scale(1,-1)">
     <path
-      id="Sketch_w0000"
+      id="issue-19_1"
       d="M 55.4688875547 -1.85809403416 A 55.5 55.5 0 0 1 26.1253 48.9665L 4.25249202985 62.3520562162 A 8.14678 8.14678 0 0 1 -4.25249 62.3521L -26.1252871412 48.9665127591 A 55.5 55.5 0 0 1 -55.4689 -1.85809L -56.1247106763 -27.4932619809 A 8.14678 8.14678 0 0 1 -51.8722 -34.8588L -29.3436004136 -47.108418725 A 55.5 55.5 0 0 1 29.3436 -47.1084L 51.8722186465 -34.8587942353 A 8.14678 8.14678 0 0 1 56.1247 -27.4933L 55.4688875547 -1.85809403416 "
-      stroke="#000000"
-      stroke-width="0.35 px"
-      style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none;fill-rule:evenodd"/>
+      style="stroke:#000;stroke-width:0.35;fill:#29292955;fill-rule:evenodd"/>
 
     <circle
-      cx="4.39931227243e-24"
-      cy="1.67346641155e-24"
-      r="13.1445"
-      stroke="#000000"
-      stroke-width="0.35 px"
-      style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
+      id="issue-19_2"
+      cx="4.39931227243e-24" cy="1.67346641155e-24" r="13.1445"
+      style="stroke:#000;stroke-width:0.35;fill:#e0e0e055" />
     <circle
-      cx="-47.9806"
-      cy="-27.7016123259"
-      r="3.3782"
-      stroke="#000000"
-      stroke-width="0.35 px"
-      style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
+      id="issue-19_3"
+      cx="-47.9806" cy="-27.7016123259" r="3.3782"
+      style="stroke:#000;stroke-width:0.35;fill:#50000055" />
     <circle
-      cx="2.61025905349e-29"
-      cy="55.4032246518"
-      r="3.3782"
-      stroke="#000000"
-      stroke-width="0.35 px"
-      style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
+      id="issue-19_4"
+      cx="2.61025905349e-29" cy="55.4032246518" r="3.3782"
+      style="stroke:#000;stroke-width:0.35;fill:#00500055" />
     <circle
-      cx="47.9806"
-      cy="-27.7016123259"
-      r="3.3782"
-      stroke="#000000"
-      stroke-width="0.35 px"
-      style="stroke-width:0.35;stroke-miterlimit:4;stroke-dasharray:none;fill:none"/>
-
-    <title>Sketch</title>
-    </g>
+      id="issue-19_5"
+      cx="47.9806" cy="-27.7016123259" r="3.3782"
+      style="stroke:#000;stroke-width:0.35;fill:#00005055" />
+  </g>
 
 
   <!-- issue inkscape-applytransforms/issues/10 - remove all scale transformations  -->
+  <text class="desc" x="680" y="1420">Issue #19 - remove all scale transformations</text>
+<!-- Shape rect not yet supported
   <rect
     id="issue-10"
-    d="  m -369.08313,-196.79971 h 76.69942 v 52.65435 h -76.69942 z"
-    style="fill:#0000ff"
-    transform="rotate(43.228035)
-                scale(1,-1)" />
+    x="350" y="20" width="100" height="100" rx="15" ry="30"
+    style="fill:#00DB67"
+    transform="translate(680, 950) rotate(45) scale(1,1)" />
+-->
 
-  <!-- test for rect -->              
-  <!--
-  <rect
-    id="issue-10"
-    y="260.50827"
-    x="-175.45432"
-    height="52.654354"
-    width="76.699425"
-    style="fill:#0000ff"
-    transform="rotate(43.228035)
-                scale(1,-1)" /> -->
+  <!-- test for rect -->
+  <text class="desc" x="380" y="1420">Rectangle</text>
+<!-- Shape rect not yet supported
+  <g id="test-path-group" transform="translate(380, 1260)">
+    <rect
+      id="rectangle"
+      y="-20.50827"
+      x="30.45432"
+      height="52.654354"
+      width="76.699425"
+      style="fill:#fff"
+      transform="rotate(30.228035, 15, 15)
+      scale(1, -1)" />
+  </g>
+-->
 
-<!--
-  text
-  image
-  use -->
 </svg>

--- a/tests/data/svg/applytransform.svg
+++ b/tests/data/svg/applytransform.svg
@@ -58,7 +58,6 @@
   </g>
 
 
-  <!-- uniform scale -->
   <circle
     cx="0"
     cy="0"
@@ -66,6 +65,9 @@
     style="fill:red;stroke-width:1.5"
     transform="scale(4)" />
 
+  <!-- issue inkscape-applytransforms/issues/15 - apply to an ellipse in a group-->
+  <g
+    id="issue-15">
   <ellipse
     cx="240"
     cy="100"
@@ -89,6 +91,8 @@
     ry="15"
     style="fill:yellow;stroke-width:1.5"
     transform="translate(-36 45.5)" />
+
+  </g>
 
   <polygon
     points="200,10 250,190 160,210"

--- a/tests/dev_requirements.txt
+++ b/tests/dev_requirements.txt
@@ -1,0 +1,5 @@
+# Dev Requirements
+pytest
+pytest-cov
+inkex
+autopep8

--- a/tests/test_applytransform.py
+++ b/tests/test_applytransform.py
@@ -1,8 +1,20 @@
 # coding=utf-8
+
+import os
+from glob import glob
+
 from applytransform import ApplyTransform
 from inkex.tester import ComparisonMixin, TestCase
+from inkex.tester.inx import InxMixin
+
 
 class TestApplyTransform(ComparisonMixin, TestCase):
     compare_file = "svg/applytransform.svg"
     effect_class = ApplyTransform
     comparisons = [()]
+
+
+class TestApplyTransformInx(InxMixin, TestCase):
+    def test_inx_file(self):
+        for inx_file in glob(os.path.join(self._testdir(), '..', '*.inx')):
+            self.assertInxIsGood(inx_file)


### PR DESCRIPTION
This further enhances the comparisons tests to help bring this to Inkscape Extensions Core (#23).

- Adds a test for issue #10.
- Adds a test for issue #15.
- Adds a test for issue #19.
- Adds tests for the not yet supported shape `rect`.
- Adds tests for the not yet supported shape `text`.
- Adds tests for the not yet supported shape `use`.
- Adds tests for Inx Files and fix inx test.
- Adds readme