### PR TITLE
Do not move unsupported objects, keep transform

### DIFF
--- a/applytransform.py
+++ b/applytransform.py
@@ -143,8 +143,9 @@ class ApplyTransform(inkex.EffectExtension):
                           inkex.addNS('text', 'svg'),
                           inkex.addNS('image', 'svg'),
                           inkex.addNS('use', 'svg')]:
+            node.attrib['transform'] = str(transf)
             inkex.utils.errormsg(
-                "Shape %s (%s) not yet supported, try Object to path first"
+                "Shape %s (%s) not yet supported. Not all transforms will be applied. Try Object to path first"
                 % (node.TAG, node.get("id"))
             )
 


### PR DESCRIPTION
It seems unnecessary to have e.g. text objects move around after applying this extension. At the cost of keeping some `transform` attributes, we can keep them at the same place.