### PR TITLE
text transformation

### DIFF
--- a/applytransform.py
+++ b/applytransform.py
@@ -133,8 +133,8 @@ class ApplyTransform(inkex.EffectExtension):
 
         # Extract translation, scaling, rotation and parent xy
         a, b, c, d = transf.a, transf.b, transf.c, transf.d
-        sx = math.sqrt(a**2 + c**2)
-        sy = math.sqrt(b**2 + d**2)
+        sx = math.sqrt(a**2 + b**2)
+        sy = math.sqrt(c**2 + d**2)
         parentx = node.getparent().get('x', '0')
         parenty = node.getparent().get('y', '0')
 

--- a/applytransform.py
+++ b/applytransform.py
@@ -181,19 +181,13 @@ class ApplyTransform(inkex.EffectExtension):
             self.transformRectangle(node, transf)
             self.scaleStrokeWidth(node, transf)
 
-        elif node.tag in [inkex.addNS('text', 'svg')]:
+        elif node.tag in [inkex.addNS('text', 'svg'),
+                          inkex.addNS('tspan', 'svg')]:
             x = float(node.get('x', '0'))
             y = float(node.get('y', '0'))
             p = transf.apply_to_point((x, y))
-            node.set("x", p[0])
-            node.set("y", p[1])
-
-        elif node.tag in [inkex.addNS('tspan', 'svg')]:
-            parent = node.getparent()
-            x = float(parent.get('x', '0'))
-            y = float(parent.get('y', '0'))
-            node.set('x', float(node.get('x', '0')) + x)
-            node.set('y', float(node.get('y', '0')) + y)
+            node.set("x", str(p[0]))
+            node.set("y", str(p[1]))
 
         elif node.tag in [inkex.addNS('image', 'svg'),
                           inkex.addNS('image', 'svg'),

--- a/applytransform.py
+++ b/applytransform.py
@@ -181,7 +181,14 @@ class ApplyTransform(inkex.EffectExtension):
             self.transformRectangle(node, transf)
             self.scaleStrokeWidth(node, transf)
 
-        elif node.tag in [inkex.addNS('text', 'svg'),
+        elif node.tag in [inkex.addNS('text', 'svg')]:
+            x = float(node.get('x', '0'))
+            y = float(node.get('y', '0'))
+            p = transf.apply_to_point((x, y))
+            node.set("x", p[0])
+            node.set("y", p[1])
+            
+        elif node.tag in [inkex.addNS('image', 'svg'),
                           inkex.addNS('image', 'svg'),
                           inkex.addNS('use', 'svg')]:
             node.attrib['transform'] = str(transf)

--- a/applytransform.py
+++ b/applytransform.py
@@ -47,7 +47,7 @@ class ApplyTransform(inkex.EffectExtension):
                 try:
                     style_attrib = self.svg.unittouu(style.get(attrib)) / self.svg.unittouu("1px")
                     style_attrib *= math.sqrt(abs(transf.a * transf.d - transf.b * transf.c))
-                    style[attrib] = str(style_attrib)
+                    style[attrib] = str(round(style_attrib, 2)) + 'px'
                     update = True
                 except AttributeError as e:
                     pass

--- a/applytransform.py
+++ b/applytransform.py
@@ -187,7 +187,14 @@ class ApplyTransform(inkex.EffectExtension):
             p = transf.apply_to_point((x, y))
             node.set("x", p[0])
             node.set("y", p[1])
-            
+
+        elif node.tag in [inkex.addNS('tspan', 'svg')]:
+            parent = node.getparent()
+            x = float(parent.get('x', '0'))
+            y = float(parent.get('y', '0'))
+            node.set('x', float(node.get('x', '0')) + x)
+            node.set('y', float(node.get('y', '0')) + y)
+
         elif node.tag in [inkex.addNS('image', 'svg'),
                           inkex.addNS('image', 'svg'),
                           inkex.addNS('use', 'svg')]:

--- a/applytransform.py
+++ b/applytransform.py
@@ -135,7 +135,6 @@ class ApplyTransform(inkex.EffectExtension):
         a, b, c, d = transf.a, transf.b, transf.c, transf.d
         sx = math.sqrt(a**2 + c**2)
         sy = math.sqrt(b**2 + d**2)
-        angle = math.degrees(math.atan2(b, a))
         parentx = node.getparent().get('x', '0')
         parenty = node.getparent().get('y', '0')
 

--- a/applytransform.py
+++ b/applytransform.py
@@ -37,17 +37,17 @@ class ApplyTransform(inkex.EffectExtension):
 
         return node
 
-    def scaleStrokeWidth(self, node, transf):
+    def scaleStyleAttrib(self, node, transf, attrib):
         if 'style' in node.attrib:
             style = node.attrib.get('style')
             style = dict(Style.parse_str(style))
             update = False
 
-            if 'stroke-width' in style:
+            if attrib in style:
                 try:
-                    stroke_width = self.svg.unittouu(style.get('stroke-width')) / self.svg.unittouu("1px")
-                    stroke_width *= math.sqrt(abs(transf.a * transf.d - transf.b * transf.c))
-                    style['stroke-width'] = str(stroke_width)
+                    style_attrib = self.svg.unittouu(style.get(attrib)) / self.svg.unittouu("1px")
+                    style_attrib *= math.sqrt(abs(transf.a * transf.d - transf.b * transf.c))
+                    style[attrib] = str(style_attrib)
                     update = True
                 except AttributeError as e:
                     pass
@@ -115,7 +115,7 @@ class ApplyTransform(inkex.EffectExtension):
             p = Path(p).to_absolute().transform(transf, True)
             node.set('d', str(Path(CubicSuperPath(p).to_path())))
 
-            self.scaleStrokeWidth(node, transf)
+            self.scaleStyleAttrib(node, transf, 'stroke-width')
 
         elif node.tag in [inkex.addNS('polygon', 'svg'),
                           inkex.addNS('polyline', 'svg')]:
@@ -132,7 +132,7 @@ class ApplyTransform(inkex.EffectExtension):
             points = ' '.join(points)
             node.set('points', points)
 
-            self.scaleStrokeWidth(node, transf)
+            self.scaleStyleAttrib(node, transf, 'stroke-width')
 
         elif node.tag in [inkex.addNS("ellipse", "svg"), inkex.addNS("circle", "svg")]:
 
@@ -179,7 +179,7 @@ class ApplyTransform(inkex.EffectExtension):
 
         elif node.tag == inkex.addNS('rect', 'svg'):
             self.transformRectangle(node, transf)
-            self.scaleStrokeWidth(node, transf)
+            self.scaleStyleAttrib(node, transf, 'stroke-width')
 
         elif node.tag in [inkex.addNS('text', 'svg'),
                           inkex.addNS('tspan', 'svg')]:
@@ -188,16 +188,16 @@ class ApplyTransform(inkex.EffectExtension):
             p = transf.apply_to_point((x, y))
             node.set("x", str(p[0]))
             node.set("y", str(p[1]))
+            self.scaleStyleAttrib(node, transf, 'font-size')
 
         elif node.tag in [inkex.addNS('image', 'svg'),
-                          inkex.addNS('image', 'svg'),
                           inkex.addNS('use', 'svg')]:
             node.attrib['transform'] = str(transf)
             inkex.utils.errormsg(f"Shape {node.TAG} ({node.get('id')}) not yet supported. Not all transforms will be applied. Try Object to path first")
 
         else:
             # e.g. <g style="...">
-            self.scaleStrokeWidth(node, transf)
+            self.scaleStyleAttrib(node, transf, 'stroke-width')
 
         for child in node.getchildren():
             self.recursiveFuseTransform(child, transf)

--- a/applytransform.py
+++ b/applytransform.py
@@ -125,8 +125,7 @@ class ApplyTransform(inkex.EffectExtension):
 
         # Add rotation if it exists
         if abs(angle) > 1e-6:
-            tr = str(f"rotate({angle:.3f} {new_x:.3f} {new_y:.3f})")
-            node.set('transform',tr)
+            node.attrib['transform'] = str(f"rotate({angle:.3f} {new_x:.3f} {new_y:.3f})")
 
     def transformTspan(self, node, transf: Transform):
         x = float(node.get('x', '0'))

--- a/tests/data/svg/applytransform.svg
+++ b/tests/data/svg/applytransform.svg
@@ -80,7 +80,6 @@
 
   <!-- test for text -->
   <text class="desc" x="380" y="1160">Text</text>
-<!-- Shape rect not yet supported
   <g
     id="text"
     transform="translate(380,1060)">
@@ -89,11 +88,9 @@
     <text id="text-3" x="55" y="55" style="font-family:sans-serif;font-style:italic;font-size:13px">is</text>
     <text id="text-4" x="65" y="55" style="font-family:serif;font-style:italic;font-size:30px" fill="red">Grumpy!</text>
   </g>
--->
 
   <!-- test for text with tspan -->
   <text class="desc" x="720" y="1160">Text with tspan</text>
-<!-- Shape text not yet supported
   <text
     id="text-tspan"
     style="font-style:oblique;font-size:18px;font-family:'DejaVu Sans'"
@@ -102,8 +99,17 @@
     <tspan id="text-tspan-1" x="40" y="20">The quick brown fox</tspan>
     <tspan id="text-tspan-2" x="80" y="40">jumps over the lazy dog.</tspan>
   </text>
--->
 
+  <!-- test for text with tspan, rotation and non uniform scaling -->
+  <text class="desc" x="1000" y="1160">Text with tspan, rotation and non uniform scaling</text>
+  <text
+    id="text-tspan-rs"
+    style="font-style:oblique;font-size:18px;font-family:'DejaVu Sans'"
+    transform="matrix(0.97,-0.24,0.73,2.91,1000,1000)">
+
+    <tspan id="text-tspan-rs-1" x="40" y="20">The quick brown fox</tspan>
+    <tspan id="text-tspan-rs-2" x="80" y="40">jumps over the lazy dog.</tspan>
+  </text>
   <!-- test for image -->
 
 


### PR DESCRIPTION
fixing https://github.com/Klowner/inkscape-applytransforms/pull/59 by applying same way of accessing attributes as used by transformRectangle
Works on both text and tspan in tests/data/svg/applytransform.svg